### PR TITLE
build: correct gitignore to make suitable for composer package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
-# Bootstrap
-app/bootstrap*
+vendor/
+composer.lock
 
-# Symfony directories
-vendor/*
-*/logs/*
-*/cache/*
-web/uploads/*
-web/bundles/*
-
-# Configuration files
-app/config/parameters.ini
-app/config/parameters.yml


### PR DESCRIPTION
The old .gitignore was years old and only relevant for a Symfony app, not a Symfony bundle.